### PR TITLE
Refactor the Maven module to match the conventions introduced in SDKMAN! module

### DIFF
--- a/cli-assured-mvn/src/main/java/org/cliassured/mvn/InstalledMaven.java
+++ b/cli-assured-mvn/src/main/java/org/cliassured/mvn/InstalledMaven.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 CLI Assured contributors as indicated by the @author tags
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.cliassured.mvn;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.cliassured.CliAssured;
+import org.cliassured.CommandSpec;
+import org.cliassured.mvn.MavenSpec.ExcludeFromJacocoGeneratedReport;
+
+/**
+ * Maven installed locally.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ * @since  0.2.0
+ */
+public class InstalledMaven {
+
+    private final Path home;
+    private final String version;
+
+    InstalledMaven(String version, Path home) {
+        this.version = Objects.requireNonNull(version, "version");
+        this.home = Objects.requireNonNull(home, "home");
+    }
+
+    /**
+     * @return the path pointing at the {@code mvn} or {@code mvn.cmd} executable of this {@link InstalledMaven}; the path
+     *         is
+     *         guaranteed to exist only after calling {@link #assertInstalled()}, {@link #installIfNeeded()} or ensuring
+     *         that {@link #isInstalled()} returns {@code true}
+     * @since  0.2.0
+     */
+    @ExcludeFromJacocoGeneratedReport
+    Path mvnPath() {
+        return home
+                .resolve("bin/mvn"
+                        + (System.getProperty("os.name").toLowerCase().contains("win") ? ".cmd" : ""));
+    }
+
+    /**
+     * @return the Maven home directory of this {@link InstalledMaven} - the one containing {@code bin/mvn[.cmd]}
+     * @since  0.0.1
+     */
+    public Path home() {
+        return home;
+    }
+
+    /**
+     * @return the Maven version of this {@link InstalledMaven}
+     * @since  0.0.1
+     */
+    public String version() {
+        return version;
+    }
+
+    /**
+     * Returns a new {@link CommandSpec} that can be used to execute a Maven command
+     * and/or define assertions on the output.
+     *
+     * @return a new {@link CommandSpec} with its executable path and arguments set
+     * @since  0.2.0
+     */
+    @ExcludeFromJacocoGeneratedReport
+    public CommandSpec mvn() {
+        final String exe = mvnPath().toString();
+        if (exe.endsWith(".cmd")) {
+            /* Windows call via cmd.exe */
+            return CliAssured.command("cmd.exe")
+                    .args("/c", exe);
+        } else {
+            /* Linux or Mac - call mvn directly */
+            return CliAssured.command(exe);
+        }
+    }
+
+    /**
+     * Resolves {@code binaryName} and {@code altBinaryNames} against {@code home() + "/bin"},
+     * selects the first of those files that exists and returns a new {@link CommandSpec} having
+     * the file set as {@link executable CommandSpec#executable(String)}.
+     * <p>
+     * {@code altBinaryNames} may come it handy when covering Windows and Unix-like platforms.
+     *
+     * @param  binaryName            name of a file under this {@link InstalledCandidate}'s {@code bin} directory
+     * @param  altBinaryNames        alternative names of files under this {@link InstalledCandidate}'s {@code bin}
+     *                               directory
+     * @return                       a new {@link CommandSpec} having executable set to an absolute path of the specified
+     *                               {@code binaryName}
+     * @throws IllegalStateException if the specified {@code binaryName} does not exist under {@link #home()}
+     * @since                        0.2.0
+     */
+    public CommandSpec bin(String binaryName, String... altBinaryNames) {
+        {
+            final Path executable = home.resolve("bin/" + binaryName);
+            if (Files.isRegularFile(executable)) {
+                return CliAssured.command(executable.toString());
+            }
+        }
+        if (altBinaryNames.length > 0) {
+            for (String altBinaryName : altBinaryNames) {
+                final Path executable = home.resolve("bin/" + altBinaryName);
+                if (Files.isRegularFile(executable)) {
+                    return CliAssured.command(executable.toString());
+                }
+            }
+            throw new IllegalStateException(
+                    "None of the requested binaries "
+                            + Stream.concat(Stream.of(binaryName), Stream.of(altBinaryNames))
+                                    .map(name -> home.resolve("bin/" + name))
+                                    .map(Path::toString)
+                                    .collect(Collectors.joining(", "))
+                            + " exists");
+        }
+        throw new IllegalStateException("The requested binary " + home.resolve("bin/" + binaryName) + " does not exist");
+    }
+}

--- a/cli-assured-mvn/src/main/java/org/cliassured/mvn/Maven.java
+++ b/cli-assured-mvn/src/main/java/org/cliassured/mvn/Maven.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 CLI Assured contributors as indicated by the @author tags
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.cliassured.mvn;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import org.cliassured.mvn.MavenSpec.ExcludeFromJacocoGeneratedReport;
+
+/**
+ * Entry methods for installing and invoking Maven.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ * @since  0.2.0
+ */
+public class Maven {
+    @ExcludeFromJacocoGeneratedReport
+    private Maven() {
+    }
+
+    /**
+     * Create a new {@link Maven} of the given version.
+     *
+     * @param  version the Maven version to select, such as {@code 3.9.11}
+     * @return         a new {@link Maven}
+     *
+     * @since          0.0.1
+     */
+    public static MavenSpec version(String version) {
+        return new MavenSpec(version);
+    }
+
+    /**
+     * Create a new {@link Maven} with the {@link #distributionUrl} looked up in
+     * {@code .mvn/wrapper/maven-wrapper.properties}
+     * relative to current directory or its nearest ancestor directory.
+     * Equivalent to {@code Mvn.fromMvnw(Paths.get(".").toAbsolutePath().normalize())}.
+     *
+     * @return                       a new {@link Maven}
+     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
+     *                               ancestors
+     *
+     * @since                        0.0.1
+     */
+    @ExcludeFromJacocoGeneratedReport
+    public static MavenSpec fromMvnw() {
+        return fromMvnw(Paths.get(".").toAbsolutePath().normalize());
+    }
+
+    /**
+     * Create a new {@link Maven} with the {@link #distributionUrl} looked up in
+     * {@code .mvn/wrapper/maven-wrapper.properties}
+     * relative to the given {@code directory} or its nearest ancestor directory.
+     *
+     * @param  directory             the directory where to start looking for {@code .mvn/wrapper/maven-wrapper.properties}
+     * @return                       a new {@link Maven}
+     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
+     *                               ancestors
+     *
+     * @since                        0.0.1
+     */
+    @ExcludeFromJacocoGeneratedReport
+    public static MavenSpec fromMvnw(Path directory) {
+        return fromMvnw(directory, MavenSpec.findM2Directory());
+    }
+
+    /**
+     * Create a new {@link Maven} with the {@link #distributionUrl} looked up in
+     * {@code .mvn/wrapper/maven-wrapper.properties}
+     * relative to current directory or its nearest ancestor directory.
+     *
+     * @param  directory             the directory where to start looking for {@code .mvn/wrapper/maven-wrapper.properties}
+     * @param  m2Directory           a custom Maven user home directory instead of the default {@code ~/.m2}
+     * @return                       a new {@link Maven}
+     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
+     *                               ancestors
+     *
+     * @since                        0.0.1
+     */
+    @ExcludeFromJacocoGeneratedReport
+    public static MavenSpec fromMvnw(Path directory, Path m2Directory) {
+        Path dir = directory;
+        while (dir != null) {
+            final Path wrapperProps = dir.resolve(".mvn/wrapper/maven-wrapper.properties");
+            if (Files.isRegularFile(wrapperProps)) {
+                Properties props = new Properties();
+                try (InputStream in = Files.newInputStream(wrapperProps)) {
+                    props.load(in);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Could not read " + wrapperProps, e);
+                }
+                return MavenSpec.fromDistributionUrl((String) props.get("distributionUrl"), m2Directory);
+            }
+            dir = dir.getParent();
+        }
+        throw new IllegalStateException(
+                "Could not find .mvn/wrapper/maven-wrapper.properties in the parent hierarchy of " + directory);
+    }
+}

--- a/cli-assured-mvn/src/main/java/org/cliassured/mvn/MavenSpec.java
+++ b/cli-assured-mvn/src/main/java/org/cliassured/mvn/MavenSpec.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -37,33 +36,16 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.cliassured.CliAssured;
-import org.cliassured.CommandSpec;
 import org.slf4j.LoggerFactory;
 
-// @formatter:off
 /**
- * A Maven version installed or installable locally under {@code ~/.m2/wrapper/dists}.
- * Can be used for invoking {@code mvn[.cmd]} after calling {@link #installIfNeeded()} or {@link #assertInstalled()} as
- * follows:
- *
- * <pre>{@code
- * Mvn.version("3.9.11")
- *         .installIfNeeded()
- *         .args("--version")
- *         .then()
- *             .stdout()
- *                 .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
- *         .execute()
- *         .assertSuccess();
- * }</pre>
+ * A specification of a Maven installation
  *
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  * @since  0.0.1
  */
-// @formatter:on
-public class Mvn {
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(Mvn.class);
+public class MavenSpec {
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(MavenSpec.class);
     private static final Pattern MAVEN_URL_PATH_PATTERN = Pattern.compile("/apache-maven-(.*)-bin\\.zip$");
     private static final Pattern MAVEN_CORE_PATTERN = Pattern.compile("^maven-core-(.*)\\.jar$");
     private static final int BUFFER_SIZE = 8192;
@@ -73,90 +55,14 @@ public class Mvn {
     private final Path home;
     private final String distributionUrl;
 
-    /**
-     * Create a new {@link Mvn} of the given version.
-     *
-     * @param  version the Maven version to select, such as {@code 3.9.11}
-     * @return         a new {@link Mvn}
-     *
-     * @since          0.0.1
-     */
-    public static Mvn version(String version) {
-        return new Mvn(version);
-    }
-
-    /**
-     * Create a new {@link Mvn} with the {@link #distributionUrl} looked up in {@code .mvn/wrapper/maven-wrapper.properties}
-     * relative to current directory or its nearest ancestor directory.
-     * Equivalent to {@code Mvn.fromMvnw(Paths.get(".").toAbsolutePath().normalize())}.
-     *
-     * @return                       a new {@link Mvn}
-     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
-     *                               ancestors
-     *
-     * @since                        0.0.1
-     */
-    @ExcludeFromJacocoGeneratedReport
-    public static Mvn fromMvnw() {
-        return fromMvnw(Paths.get(".").toAbsolutePath().normalize());
-    }
-
-    /**
-     * Create a new {@link Mvn} with the {@link #distributionUrl} looked up in {@code .mvn/wrapper/maven-wrapper.properties}
-     * relative to the given {@code directory} or its nearest ancestor directory.
-     *
-     * @param  directory             the directory where to start looking for {@code .mvn/wrapper/maven-wrapper.properties}
-     * @return                       a new {@link Mvn}
-     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
-     *                               ancestors
-     *
-     * @since                        0.0.1
-     */
-    @ExcludeFromJacocoGeneratedReport
-    public static Mvn fromMvnw(Path directory) {
-        return fromMvnw(directory, findM2Directory());
-    }
-
-    /**
-     * Create a new {@link Mvn} with the {@link #distributionUrl} looked up in {@code .mvn/wrapper/maven-wrapper.properties}
-     * relative to current directory or its nearest ancestor directory.
-     *
-     * @param  directory             the directory where to start looking for {@code .mvn/wrapper/maven-wrapper.properties}
-     * @param  m2Directory           a custom Maven user home directory instead of the default {@code ~/.m2}
-     * @return                       a new {@link Mvn}
-     * @throws IllegalStateException if {@code .mvn/wrapper/maven-wrapper.properties} cannot be found under any of the
-     *                               ancestors
-     *
-     * @since                        0.0.1
-     */
-    @ExcludeFromJacocoGeneratedReport
-    public static Mvn fromMvnw(Path directory, Path m2Directory) {
-        Path dir = directory;
-        while (dir != null) {
-            final Path wrapperProps = dir.resolve(".mvn/wrapper/maven-wrapper.properties");
-            if (Files.isRegularFile(wrapperProps)) {
-                Properties props = new Properties();
-                try (InputStream in = Files.newInputStream(wrapperProps)) {
-                    props.load(in);
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Could not read " + wrapperProps, e);
-                }
-                return fromDistributionUrl((String) props.get("distributionUrl"), m2Directory);
-            }
-            dir = dir.getParent();
-        }
-        throw new IllegalStateException(
-                "Could not find .mvn/wrapper/maven-wrapper.properties in the parent hierarchy of " + directory);
-    }
-
-    private Mvn(String version) {
+    MavenSpec(String version) {
         this.version = Objects.requireNonNull(version, "version");
         this.m2Directory = findM2Directory();
         this.distributionUrl = defaultDistributionUrl(version);
         this.home = null;
     }
 
-    private Mvn(String version, Path m2Directory, Path home, String downloadUrl) {
+    MavenSpec(String version, Path m2Directory, Path home, String downloadUrl) {
         this.version = Objects.requireNonNull(version, "version");
         this.m2Directory = m2Directory;
         this.home = home;
@@ -167,11 +73,11 @@ public class Mvn {
      * Set a different Maven user home directory instead of the default {@code ~/.m2}.
      *
      * @param  m2Directory the {@code .m2} directory path
-     * @return             an adjusted copy of this {@link Mvn}
+     * @return             an adjusted copy of this {@link MavenSpec}
      * @since              0.0.1
      */
-    public Mvn m2Directory(Path m2Directory) {
-        return new Mvn(version, m2Directory, home, distributionUrl);
+    public MavenSpec m2Directory(Path m2Directory) {
+        return new MavenSpec(version, m2Directory, home, distributionUrl);
     }
 
     /**
@@ -180,15 +86,15 @@ public class Mvn {
      * Maven home is the directory containing {@code bin/mvn[.cmd]}.
      *
      * @param  m2Directory the {@code .m2} directory path
-     * @return             an adjusted copy of this {@link Mvn}
+     * @return             an adjusted copy of this {@link MavenSpec}
      * @since              0.0.1
      */
-    public Mvn home(Path home) {
-        return new Mvn(version, m2Directory, home, distributionUrl);
+    public MavenSpec home(Path home) {
+        return new MavenSpec(version, m2Directory, home, distributionUrl);
     }
 
     /**
-     * @return the Maven home directory of this {@link Mvn} - the one containing {@code bin/mvn[.cmd]}
+     * @return the Maven home directory of this {@link MavenSpec} - the one containing {@code bin/mvn[.cmd]}
      * @since  0.0.1
      */
     public Path home() {
@@ -196,51 +102,28 @@ public class Mvn {
     }
 
     /**
-     * Set the distribution URL from which {@link Mvn} can be installed instead of the default that is computed based
+     * Set the distribution URL from which {@link MavenSpec} can be installed instead of the default that is computed based
      * on the {@link #version(String)} using the template
      * {@code https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/<version>/apache-maven-<version>-bin.zip}
      *
      * @param  distributionUrl the distribution URL
-     * @return                 an adjusted copy of this {@link Mvn}
+     * @return                 an adjusted copy of this {@link MavenSpec}
      * @since                  0.0.1
      */
-    public Mvn distributionUrl(String distributionUrl) {
-        return new Mvn(version, m2Directory, home, distributionUrl);
-    }
-
-    /**
-     * @return the path pointing at the {@code mvn} or {@code mvn.cmd} executable of this {@link Mvn}; the path is
-     *         guaranteed to exist only after calling {@link #assertInstalled()}, {@link #installIfNeeded()} or ensuring
-     *         that {@link #isInstalled()} returns {@code true}
-     * @since  0.0.1
-     */
-    public String executable() {
-        return executablePath()
-                .toString();
-    }
-
-    /**
-     * @return the path pointing at the {@code mvn} or {@code mvn.cmd} executable of this {@link Mvn}; the path is
-     *         guaranteed to exist only after calling {@link #assertInstalled()}, {@link #installIfNeeded()} or ensuring
-     *         that {@link #isInstalled()} returns {@code true}
-     * @since  0.0.1
-     */
-    @ExcludeFromJacocoGeneratedReport
-    public Path executablePath() {
-        return home()
-                .resolve("bin/mvn"
-                        + (System.getProperty("os.name").toLowerCase().contains("win") ? ".cmd" : ""));
+    public MavenSpec distributionUrl(String distributionUrl) {
+        return new MavenSpec(version, m2Directory, home, distributionUrl);
     }
 
     /**
      * Install this Maven version or fail if the version is installed already.
      *
-     * @return                       a possibly new {@link Mvn} instance pointing at the freshly installed Maven version
+     * @return                       a possibly new {@link MavenSpec} instance pointing at the freshly installed Maven
+     *                               version
      * @throws IllegalStateException if this Maven version is installed already
      * @since                        0.0.1
      */
     @ExcludeFromJacocoGeneratedReport
-    public Mvn install() {
+    public InstalledMaven install() {
         final Path home = home();
         if (Files.exists(home)) {
             throw new IllegalStateException(
@@ -320,26 +203,27 @@ public class Mvn {
                 }
             }
         }
-        return new Mvn(version, m2Directory, home, distributionUrl);
+        return new InstalledMaven(version, home);
     }
 
     /**
-     * @return                this {@link Mvn}
+     * @return                this {@link MavenSpec}
      * @throws AssertionError if this Maven version is not installed yet
      */
     @ExcludeFromJacocoGeneratedReport
-    public Mvn assertInstalled() {
+    public InstalledMaven assertInstalled() {
         final Path home = home();
         if (!Files.isDirectory(home)) {
             throw new AssertionError("Maven " + version + " is not installed in " + home
                     + " (directory does not exist). You may want to set Mvn.home(Path) or call Mvn.installIfNeeded()");
         }
-        final Path executable = executablePath();
+
+        final Path executable = new InstalledMaven(version, home).mvnPath();
         if (!Files.isRegularFile(executable)) {
             throw new AssertionError("Maven " + version + " is not installed in " + home
                     + " (bin/mvn[.cmd] does not exist). You may want to set Mvn.home(Path) or call Mvn.installIfNeeded()");
         }
-        return this;
+        return new InstalledMaven(version, home);
     }
 
     /**
@@ -349,45 +233,24 @@ public class Mvn {
     @ExcludeFromJacocoGeneratedReport
     public boolean isInstalled() {
         final Path home = home();
-        return Files.isDirectory(home) && Files.isRegularFile(executablePath());
+        return Files.isDirectory(home) && Files.isRegularFile(new InstalledMaven(version, home).mvnPath());
     }
 
     /**
      * Install this Maven version unless it is installed already.
      *
-     * @return a possibly new {@link Mvn} instance pointing at the freshly installed Maven version
+     * @return a possibly new {@link MavenSpec} instance pointing at the freshly installed Maven version
      * @since  0.0.1
      */
-    public Mvn installIfNeeded() {
+    public InstalledMaven installIfNeeded() {
         if (!isInstalled()) {
             return install();
         }
-        return this;
-    }
-
-    /**
-     * Set Maven command line arguments and return a new {@link CommandSpec} that can be used to execute a Maven command
-     * and/or define assertions on the output.
-     *
-     * @param  args the Maven command line arguments to set
-     * @return      a new {@link CommandSpec} with its executable path and arguments set
-     */
-    @ExcludeFromJacocoGeneratedReport
-    public CommandSpec args(String... args) {
-        final String exe = executable();
-        if (exe.endsWith(".cmd")) {
-            /* Windows call via cmd.exe */
-            return CliAssured.command("cmd.exe")
-                    .args("/c", exe)
-                    .args(args);
-        } else {
-            /* Linux or Mac - call mvn directly */
-            return CliAssured.command(exe, args);
-        }
+        return new InstalledMaven(version, home());
     }
 
     @ExcludeFromJacocoGeneratedReport
-    static Mvn fromDistributionUrl(String distributionUrl, Path m2Directory) {
+    static MavenSpec fromDistributionUrl(String distributionUrl, Path m2Directory) {
         final Path distsDir = m2Directory.resolve("wrapper/dists");
         final String hash = hashString(distributionUrl);
         final Optional<Path> mavenHome;
@@ -416,7 +279,7 @@ public class Mvn {
             version = findVersion(mavenHome.get());
         }
 
-        return new Mvn(version, m2Directory, mavenHome.orElse(null), distributionUrl);
+        return new MavenSpec(version, m2Directory, mavenHome.orElse(null), distributionUrl);
     }
 
     static String defaultDistributionUrl(String version) {

--- a/cli-assured-mvn/src/test/java/org/cliassured/mvn/MvnTest.java
+++ b/cli-assured-mvn/src/test/java/org/cliassured/mvn/MvnTest.java
@@ -12,7 +12,7 @@ public class MvnTest {
     void hashString() {
         Assertions
                 .assertThat(
-                        Mvn.hashString(
+                        MavenSpec.hashString(
                                 "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip"))
                 .isEqualTo("a2d47e15");
     }

--- a/cli-assured-sdkman/src/main/java/org/cliassured/sdkman/InstalledCandidate.java
+++ b/cli-assured-sdkman/src/main/java/org/cliassured/sdkman/InstalledCandidate.java
@@ -19,21 +19,19 @@ import org.cliassured.CommandSpec;
  */
 public class InstalledCandidate {
     private final Path home;
-    private final Path bin;
 
     InstalledCandidate(Path home) {
         this.home = home;
-        this.bin = home.resolve("bin");
     }
 
     /**
-     * Resolves {@code binaryName} and {@code altBinaryNames} against {@link #home()},
+     * Resolves {@code binaryName} and {@code altBinaryNames} against {@code home() + "/bin"},
      * selects the first of those files that exists and returns a new {@link CommandSpec} having
      * the file set as {@link executable CommandSpec#executable(String)}.
      * <p>
      * {@code altBinaryNames} may come it handy when covering Windows and Unix-like platforms.
      * E.g. to resolve {@code java} on Linux and {@code java.exe} on Windows you would call
-     * {@code bin("java", "java.exe")}. For Maven, you may need to call {@code bin("mvn", "mvn.cmd")}
+     * {@code bin("java", "java.exe")}.
      *
      * @param  binaryName            name of a file under this {@link InstalledCandidate}'s {@code bin} directory
      * @param  altBinaryNames        alternative names of files under this {@link InstalledCandidate}'s {@code bin}
@@ -44,6 +42,7 @@ public class InstalledCandidate {
      * @since                        0.2.0
      */
     public CommandSpec bin(String binaryName, String... altBinaryNames) {
+        final Path bin = home.resolve("bin");
         {
             final Path executable = bin.resolve(binaryName);
             if (Files.isRegularFile(executable)) {
@@ -76,11 +75,4 @@ public class InstalledCandidate {
         return home;
     }
 
-    /**
-     * @return bin directory of this {@link InstalledCandidate}, typically {@code $SDKMAN_DIR/<candidate>/<version>/bin}
-     * @since  0.2.0
-     */
-    public Path bin() {
-        return bin;
-    }
 }

--- a/cli-assured-tests-java21/src/test/java/org/cliassured/mvn/test/java21/QuarkusDevModeTest.java
+++ b/cli-assured-tests-java21/src/test/java/org/cliassured/mvn/test/java21/QuarkusDevModeTest.java
@@ -24,7 +24,8 @@ import org.awaitility.Awaitility;
 import org.cliassured.Await;
 import org.cliassured.Await.LineAwait;
 import org.cliassured.CommandProcess;
-import org.cliassured.mvn.Mvn;
+import org.cliassured.mvn.InstalledMaven;
+import org.cliassured.mvn.Maven;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -47,9 +48,9 @@ public class QuarkusDevModeTest {
             throw new UncheckedIOException("Could not create " + tempProject.getParent(), e);
         }
 
-        final Mvn mvn = Mvn.fromMvnw().installIfNeeded();
+        final InstalledMaven mvn = Maven.fromMvnw().installIfNeeded();
         mvn
-                .args(
+                .mvn().args(
                         "-ntp",
                         "io.quarkus:quarkus-maven-plugin:" + quarkusVersion + ":create",
                         "-DprojectGroupId=org.cli-assured",
@@ -68,7 +69,7 @@ public class QuarkusDevModeTest {
         final List<Long> pids = new ArrayList<>();
         final LineAwait<String> await = Await.lineContaining("Installed features: [");
         try (CommandProcess mvnProcess = mvn
-                .args(
+                .mvn().args(
                         "-ntp",
                         "-Dquarkus.analytics.disabled=true",
                         "-Ddebug=false", // Disable Java debugger

--- a/cli-assured-tests-java21/src/test/java/org/cliassured/test/j21/docs/MvnTest.java
+++ b/cli-assured-tests-java21/src/test/java/org/cliassured/test/j21/docs/MvnTest.java
@@ -5,7 +5,7 @@
 package org.cliassured.test.j21.docs;
 
 // tag::imports[]
-import org.cliassured.mvn.Mvn;
+import org.cliassured.mvn.Maven;
 // end::imports[]
 import org.junit.jupiter.api.Test;
 
@@ -16,16 +16,15 @@ public class MvnTest {
         // @formatter:off
         // tag::snippet[]
         // Use Maven version 3.9.11 as available in ~/.m2/wrapper/dists/apache-maven-3.9.11/a2d47e15
-        Mvn.version("3.9.11")
+        Maven.version("3.9.11")
             // If ~/.m2/wrapper/dists/apache-maven-3.9.11/a2d47e15 does not exist,
             // download it from
             // https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
             // much like Maven Wrapper would do.
-            // You can omit this, if you are sure the specified version is already installed
-            // by running mvnw or by invoking installIfNeeded() or install().
             .installIfNeeded()
-            // Mvn.version(String) and installIfNeeded() methods return a CommandSpec,
-            // so the rest is a standard cli-assured code
+            // Obtain a CommandSpec with bin/mvn[.cmd] set as executable
+            .mvn()
+            // Call `mvn[.cmd] --version`
             .args("--version")
             .then()
                 .stdout()
@@ -41,15 +40,15 @@ public class MvnTest {
         // @formatter:off
         // tag::fromMvnw[]
         // Find .mvn/wrapper/maven-wrapper.properties
-        // under the nearest ancestor,
+        // under the nearest ancestor of the current directory,
         // extract the distribution URL from there
         // find Maven version from the distribution URL
-        // and use all of that to create a new Mvn instance
-        Mvn.fromMvnw()
-            // You can omit this, if you are sure mvnw was run before
+        // and use that information to create a new Mvn instance
+        Maven.fromMvnw()
             .installIfNeeded()
-            // Mvn.fromMvnw() and installIfNeeded() methods return a CommandSpec,
-            // so the rest is a standard cli-assured code
+            // Obtain a CommandSpec with bin/mvn[.cmd] set as executable
+            .mvn()
+            // Call `mvn[.cmd] --version`
             .args("--version")
             .then()
                 .stdout()

--- a/cli-assured-tests/src/test/java/org/cliassured/mvn/test/MvnTest.java
+++ b/cli-assured-tests/src/test/java/org/cliassured/mvn/test/MvnTest.java
@@ -24,7 +24,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.cliassured.CliAssured;
-import org.cliassured.mvn.Mvn;
+import org.cliassured.mvn.InstalledMaven;
+import org.cliassured.mvn.Maven;
+import org.cliassured.mvn.MavenSpec;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -45,11 +47,11 @@ public class MvnTest {
                 .execute()
                 .assertSuccess();
 
-        Mvn mvnw = Mvn.fromMvnw();
+        MavenSpec mvnw = Maven.fromMvnw();
 
         Assertions.assertThat(mvnw.isInstalled()).isTrue();
 
-        mvnw.args("--version")
+        mvnw.assertInstalled().mvn().args("--version")
                 .then()
                 .stdout()
                 .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
@@ -62,22 +64,48 @@ public class MvnTest {
 
         final Path m2Dir = Paths.get("target/m2-" + UUID.randomUUID());
 
-        final Mvn mvnw = Mvn.fromMvnw(
+        final MavenSpec mvnw = Maven.fromMvnw(
                 Paths.get("target/test-classes/test-project").toAbsolutePath().normalize(),
                 m2Dir);
 
         Assertions.assertThat(mvnw.isInstalled()).isFalse();
 
-        mvnw
-                .installIfNeeded()
-                .args("--version")
+        final InstalledMaven installedMvn = mvnw.installIfNeeded();
+
+        installedMvn
+                .mvn().args("--version")
                 .then()
                 .stdout()
                 .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
                 .execute()
                 .assertSuccess();
 
-        Assertions.assertThat(m2Dir.resolve("wrapper/dists/apache-maven-3.9.11/a2d47e15/bin/mvn")).isRegularFile();
+        final Path mvnPath = m2Dir.resolve("wrapper/dists/apache-maven-3.9.11/a2d47e15/bin/mvn");
+        Assertions.assertThat(mvnPath).isRegularFile();
+
+        String mvnScript = isWindows ? "mvn.cmd" : "mvn";
+
+        installedMvn.bin(mvnScript).args("--version")
+                .then()
+                .stdout()
+                .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
+                .execute()
+                .assertSuccess();
+
+        installedMvn.bin("foo", mvnScript).args("--version")
+                .then()
+                .stdout()
+                .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
+                .execute()
+                .assertSuccess();
+
+        Assertions.assertThatThrownBy(() -> installedMvn.bin("foo")).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not exist");
+        Assertions.assertThatThrownBy(() -> installedMvn.bin("foo", "bar")).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("None of the requested binaries");
+
+        Assertions.assertThat(installedMvn.version()).isEqualTo("3.9.11");
+        Assertions.assertThat(installedMvn.home()).isEqualTo(m2Dir.resolve("wrapper/dists/apache-maven-3.9.11/a2d47e15"));
 
     }
 
@@ -85,7 +113,7 @@ public class MvnTest {
     void installIfNeeded() throws IOException {
         final Path m2Dir = Paths.get("target/m2-" + UUID.randomUUID());
         final String version = "3.9.11";
-        Mvn mvn = Mvn.version(version)
+        MavenSpec mvn = Maven.version(version)
                 .m2Directory(m2Dir);
         Assertions.assertThat(mvn.isInstalled()).isFalse();
 
@@ -96,7 +124,7 @@ public class MvnTest {
                 .isInstanceOf(AssertionError.class)
                 .hasMessageStartingWith("Maven 3.9.11 is not installed ");
 
-        mvn = mvn.installIfNeeded();
+        InstalledMaven installedMaven = mvn.installIfNeeded();
 
         Assertions.assertThat(mvn.isInstalled()).isTrue();
 
@@ -104,7 +132,7 @@ public class MvnTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageEndingWith("because it exists already");
 
-        CliAssured.command(mvn.executable(), "-v")
+        installedMaven.mvn().args("-v")
                 .then()
                 .stdout()
                 .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
@@ -150,12 +178,12 @@ public class MvnTest {
                         diffs.stream().map(Object::toString).collect(java.util.stream.Collectors.joining("\n")))
                 .isEmpty();
 
-        /* Because isInstalled() returns true */
-        Assertions.assertThat(mvn.installIfNeeded()).isSameAs(mvn);
+        /* Make Jacoco happy */
+        mvn.installIfNeeded();
 
-        Mvn customHome = Mvn.version(version).home(unzipDirRootDir);
+        MavenSpec customHome = Maven.version(version).home(unzipDirRootDir);
         Assertions.assertThat(customHome.isInstalled()).isTrue();
-        customHome.args("--version")
+        customHome.assertInstalled().mvn().args("--version")
                 .then()
                 .stdout()
                 .hasLines("Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)")
@@ -167,7 +195,19 @@ public class MvnTest {
     @Test
     void distributionUrl() throws IOException {
         final String version = "3.9.12";
-        Mvn mvn = Mvn.version(version)
+        MavenSpec mvn = Maven.version(version)
+                .m2Directory(Paths.get("src/test/resources/m2"))
+                .distributionUrl("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" + version
+                        + "/apache-maven-" + version + "-bin.zip");
+        Assertions.assertThat(mvn.home())
+                .isEqualTo(Paths.get("src/test/resources/m2/wrapper/dists/apache-maven-3.9.12/6068d197"));
+        Assertions.assertThat(mvn.isInstalled()).isFalse();
+    }
+
+    @Test
+    void bin() throws IOException {
+        final String version = "3.9.12";
+        MavenSpec mvn = Maven.version(version)
                 .m2Directory(Paths.get("src/test/resources/m2"))
                 .distributionUrl("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" + version
                         + "/apache-maven-" + version + "-bin.zip");

--- a/cli-assured-tests/src/test/java/org/cliassured/sdkman/test/SdkmanTest.java
+++ b/cli-assured-tests/src/test/java/org/cliassured/sdkman/test/SdkmanTest.java
@@ -57,7 +57,6 @@ public class SdkmanTest {
 
             Assertions.assertThat(sdkSpec.home().resolve("candidates/maven/3.9.11/bin/"
                     + mvnScriptName)).isRegularFile();
-            Assertions.assertThat(mvn3911.bin().resolve(mvnScriptName)).isRegularFile();
         }
 
         {
@@ -75,7 +74,6 @@ public class SdkmanTest {
 
             Assertions.assertThat(sdkSpec.home().resolve("candidates/maven/3.9.12/bin/"
                     + mvnScriptName)).isRegularFile();
-            Assertions.assertThat(mvn3912.bin().resolve(mvnScriptName)).isRegularFile();
         }
 
     }

--- a/docs/modules/ROOT/examples/j21/MvnTest.java
+++ b/docs/modules/ROOT/examples/j21/MvnTest.java
@@ -5,7 +5,7 @@
 package org.cliassured.test.j21.docs;
 
 // tag::imports[]
-import org.cliassured.mvn.Mvn;
+import org.cliassured.mvn.Maven;
 // end::imports[]
 import org.junit.jupiter.api.Test;
 
@@ -16,16 +16,15 @@ public class MvnTest {
         // @formatter:off
         // tag::snippet[]
         // Use Maven version 3.9.11 as available in ~/.m2/wrapper/dists/apache-maven-3.9.11/a2d47e15
-        Mvn.version("3.9.11")
+        Maven.version("3.9.11")
             // If ~/.m2/wrapper/dists/apache-maven-3.9.11/a2d47e15 does not exist,
             // download it from
             // https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
             // much like Maven Wrapper would do.
-            // You can omit this, if you are sure the specified version is already installed
-            // by running mvnw or by invoking installIfNeeded() or install().
             .installIfNeeded()
-            // Mvn.version(String) and installIfNeeded() methods return a CommandSpec,
-            // so the rest is a standard cli-assured code
+            // Obtain a CommandSpec with bin/mvn[.cmd] set as executable
+            .mvn()
+            // Call `mvn[.cmd] --version`
             .args("--version")
             .then()
                 .stdout()
@@ -41,15 +40,15 @@ public class MvnTest {
         // @formatter:off
         // tag::fromMvnw[]
         // Find .mvn/wrapper/maven-wrapper.properties
-        // under the nearest ancestor,
+        // under the nearest ancestor of the current directory,
         // extract the distribution URL from there
         // find Maven version from the distribution URL
-        // and use all of that to create a new Mvn instance
-        Mvn.fromMvnw()
-            // You can omit this, if you are sure mvnw was run before
+        // and use that information to create a new Mvn instance
+        Maven.fromMvnw()
             .installIfNeeded()
-            // Mvn.fromMvnw() and installIfNeeded() methods return a CommandSpec,
-            // so the rest is a standard cli-assured code
+            // Obtain a CommandSpec with bin/mvn[.cmd] set as executable
+            .mvn()
+            // Call `mvn[.cmd] --version`
             .args("--version")
             .then()
                 .stdout()

--- a/docs/modules/ROOT/pages/reference/install-and-invoke-maven.adoc
+++ b/docs/modules/ROOT/pages/reference/install-and-invoke-maven.adoc
@@ -8,7 +8,7 @@ The utility methods for installing and invoking Maven are available in `cli-assu
 ----
 <dependency>
   <groupId>org.cli-assured</groupId>
-  <artifactId>cli-assured-mvn</artifactId>
+  <artifactId>cli-assured-maven</artifactId>
   <version><!-- Use the latest --></version>
 </dependency>
 ----


### PR DESCRIPTION
* Allow querying the bin folder
* Prepare for having more commands than mvn
* Make it impossible to invoke mvn before installing it